### PR TITLE
provide loading table info functionality

### DIFF
--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -2,6 +2,8 @@
   <div class="q-pa-md">
     <q-table
       virtual-scroll
+      :loading="loading"
+      :no-data-label="noDataLabel"
       :data="data"
       :columns="columns"
       :row-key="row_key"
@@ -63,7 +65,13 @@
 export default {
   name: 'Table',
   props: [
-    'columns', 'data', 'row_key', 'pagination', 'selectedIds',
+    'columns',
+    'data',
+    'row_key',
+    'pagination',
+    'selectedIds',
+    'loading',
+    'noDataLabel',
   ],
   computed: {
     selectedArr: {

--- a/src/pages/Lessons.vue
+++ b/src/pages/Lessons.vue
@@ -1,6 +1,18 @@
 <template>
-  <q-page class="flex">
+  <q-page
+    v-if="lessons && !lessons.length && loading"
+    class="flex justify-center flex-center"
+  >
+    <QSpinnerHourglass
+      size="10em"
+      color="primary"
+      class="center"
+    />
+  </q-page>
+  <q-page v-else class="flex">
     <Table
+      :loading="loading"
+      noDataLabel="Не удалось получить список уроков..."
       :columns="columns"
       :data="lessons"
       row_key="id"

--- a/src/pages/Listeners.vue
+++ b/src/pages/Listeners.vue
@@ -1,11 +1,23 @@
 <template>
-  <q-page class="flex column">
+  <q-page
+    v-if="listeners && !listeners.length && loading"
+    class="flex justify-center flex-center"
+  >
+    <QSpinnerHourglass
+      size="10em"
+      color="primary"
+      class="center"
+    />
+  </q-page>
+  <q-page v-else class="flex column">
     <Autocomplete
       :stringOptions="seminarsOptions"
       @autocomplete-filter="filterSeminarsList"
       @make-filter="filterListeners"
     />
     <Table
+      :loading="loading"
+      noDataLabel="Не удалось получить список слушателей..."
       :columns="columns"
       :data="listeners"
       row_key="id"

--- a/src/pages/Preachers.vue
+++ b/src/pages/Preachers.vue
@@ -1,6 +1,18 @@
 <template>
-  <q-page class="flex">
+  <q-page
+    v-if="preacher && !preachers.length && loading"
+    class="flex justify-center flex-center"
+  >
+    <QSpinnerHourglass
+      size="10em"
+      color="primary"
+      class="center"
+    />
+  </q-page>
+  <q-page v-else class="flex">
     <Table
+      :loading="loading"
+      noDataLabel="Не удалось получить список проповедников..."
       :columns="columns"
       :data="preachers"
       row_key="id"

--- a/src/pages/Seminars.vue
+++ b/src/pages/Seminars.vue
@@ -1,6 +1,18 @@
 <template>
-  <q-page class="flex">
+  <q-page
+    v-if="seminars && !seminars.length && loading"
+    class="flex justify-center flex-center"
+  >
+    <QSpinnerHourglass
+      size="10em"
+      color="primary"
+      class="center"
+    />
+  </q-page>
+  <q-page v-else class="flex">
     <Table
+      :loading="loading"
+      noDataLabel="Не удалось получить список семинаров..."
       :columns="columns"
       :data="seminars"
       row_key="id"


### PR DESCRIPTION
In this pull request I add some functionality, that is necessary for loading pages info:
1) When info is loading firstly, there are HourGlasses spinner in the main layout.
2) When info is loading not firstly, there are loading line below table header.
3) When there is no information, there are custom label on each page.